### PR TITLE
Reduce help spam when run without command

### DIFF
--- a/main.py
+++ b/main.py
@@ -422,9 +422,8 @@ async def main_async() -> None:
                 await asyncio.Event().wait()
                 return
             else:
-                # Exit cleanly (code 0) so the platform doesn’t treat it as a crash.
-                parser.print_help()
-                print_examples()
+                # Quiet exit when no command is supplied to avoid repeated help spam.
+                log.info("No command provided. Exiting.")
                 return
 
     async with httpx.AsyncClient(headers={"User-Agent": "kg2-ai/1.3"}, http2=True) as client:


### PR DESCRIPTION
## Summary
- exit quietly when main.py runs without subcommand or START_CMD

## Testing
- `python -m py_compile main.py`
- `START_CMD= KEEP_ALIVE=0 python main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b524dc0418833387c797d5d0ee4866